### PR TITLE
fix: resolve issue where generated image files were empty

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -61,23 +61,38 @@ class Generator {
   }
 
   processFile(src) {
+    let transmuter;
+    let transmutedData = {};
+
     const transmuters = [...this.transmuters];
-    const { ext } = path.parse(src);
-    const { content, data } = matter(fs.readFileSync(src));
+    const { ext, name } = path.parse(src);
     const context = { src: this.src, dest: this.dest, layouts: this.layouts };
 
-    let transmuter = null;
-    let transmutedData = { content, data, ext };
+    const fileBuffer = fs.readFileSync(src);
 
-    transmuter = transmuters.shift();
-
+    const jpg = b => b.slice(0, 3).equals(Buffer.from([255, 216, 255]));
+    const png = b => b.slice(0, 8).equals(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]));
     const write = s => fs.writeFileSync(this.createDestPath(src), s);
     const copy = () => fs.copyFileSync(src, this.createDestPath(src));
-
     const transmutate = (transmutation) => {
       transmutedData = { ...transmutedData, ...transmutation };
       transmuter = transmuters.shift();
     };
+
+    const image = jpg(fileBuffer) || png(fileBuffer);
+
+    transmutedData.ext = ext;
+    transmutedData.name = name;
+    transmutedData.data = null;
+    transmutedData.content = fileBuffer;
+
+    if (!image) {
+      const { content, data } = matter(fileBuffer);
+      transmutedData.content = content;
+      transmutedData.data = data;
+    }
+
+    transmuter = transmuters.shift();
 
     while (transmuter) {
       transmuter(context, transmutedData, transmutate);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "alchemy",
+  "name": "@alchemy-js/alchemy",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/test/testData.js
+++ b/test/testData.js
@@ -1,89 +1,79 @@
-module.exports = [{ 
+module.exports = [{
   type: 'dir',
   path: './test/fixture/',
-  content: null,
-}, { 
+}, {
   type: 'dir',
   path: './test/fixture/layouts',
-  content: null
-},  { 
+}, {
   type: 'dir',
   path: './test/fixture/public',
-  content: null
-}, , { 
+}, {
   type: 'file',
   path: './test/fixture/public/index.md',
   content: Buffer.from('---\ntitle: Hello World\n---\n\n# Hello World!'),
-}, { 
+}, {
   type: 'dir',
   path: './test/fixture/public/images',
-  content: null
-}, { 
+}, {
   type: 'file',
   path: './test/fixture/public/images/header.png',
-  content: null
-}, { 
+  content: Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]),
+}, {
+  type: 'file',
+  path: './test/fixture/public/images/background.jpg',
+  content: Buffer.from([255, 216, 255]),
+}, {
   type: 'dir',
   path: './test/fixture/public/images/icons',
-  content: null
-}, { 
+}, {
   type: 'file',
   path: './test/fixture/public/images/icons/icon.svg',
-  content: null
-}, { 
+}, {
   type: 'dir',
   path: './test/fixture/public/scripts',
-  content: null
-}, { 
+}, {
   type: 'file',
   path: './test/fixture/public/scripts/main.js',
-  content: null
-}, { 
+}, {
   type: 'dir',
   path: './test/fixture/public/styles',
-  content: null
-}, { 
+}, {
   type: 'file',
   path: './test/fixture/public/styles/main.scss',
-  content: null
-}, { 
+}, {
   type: 'dir',
   path: './test/fixture/data',
-  content: null
-}, { 
+}, {
   type: 'file',
   path: './test/fixture/data/index.md',
   content: Buffer.from('---\ntitle: Hello World\n---\n\n# Hello World!'),
-}, { 
+}, {
   type: 'dir',
   path: './test/fixture/data/images',
-  content: null
-}, { 
+}, {
   type: 'file',
   path: './test/fixture/data/images/header.png',
-  content: null
-}, { 
+  content: Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]),
+}, {
+  type: 'file',
+  path: './test/fixture/data/images/background.jpg',
+  content: Buffer.from([255, 216, 255]),
+}, {
   type: 'dir',
   path: './test/fixture/data/images/icons',
-  content: null
-}, { 
+}, {
   type: 'file',
   path: './test/fixture/data/images/icons/icon.svg',
-  content: null
-}, { 
+}, {
   type: 'dir',
   path: './test/fixture/data/scripts',
-  content: null
-}, { 
+}, {
   type: 'file',
   path: './test/fixture/data/scripts/main.js',
-  content: null
-}, { 
+}, {
   type: 'dir',
   path: './test/fixture/data/styles',
-  content: null
-}, { 
+}, {
   type: 'file',
   path: './test/fixture/data/styles/main.scss',
-  content: null
 }];


### PR DESCRIPTION
Updates and refactors `processFile` method to avoid passing images through `gray-matter` module, as this resulted in incorrect encoding of these files. As a result, image files generated were empty.

Added new functions that check if a `Buffer` contains decimal values that represent each format's respective signature/magic numbers (first 8 bytes for PNG and first 3 bytes for JPG).

- https://www.ntfs.com/jpeg-signature-format.htm
- https://www.w3.org/TR/PNG/#5PNG-file-signature
 