### PR TITLE
fix: remove extensionMapper and improve transmuter callback

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -13,7 +13,6 @@ class Generator {
     assert(options.dest, '"dest" directory path required.');
     assert(options.layouts, '"layouts" directory path required.');
     this.transmuters = [];
-    this.extensionMap = {};
     this.filesystemQueue = [];
     this.logger = new Logger();
     this.listener = new Listener();
@@ -34,14 +33,14 @@ class Generator {
     this.listener.onChange(paths, () => this.clean().build());
   }
 
-  createDestPath(src) {
-    const parsedPath = path.parse(src);
+  createDestPath(srcPath, transmutedData = {}) {
+    const parsedPath = path.parse(srcPath);
     const { dir, ext, name } = parsedPath;
     const parent = dir.split(this.src);
     return path.format({
-      name,
+      ext: transmutedData.ext || ext,
+      name: transmutedData.name || name,
       dir: path.join(parent[0], this.dest, parent[1]),
-      ext: this.extensionMap[ext] || ext,
     });
   }
 
@@ -50,30 +49,25 @@ class Generator {
     return this;
   }
 
-  extensionMapper(extensionMap) {
-    this.extensionMap = extensionMap;
-    return this;
-  }
-
   processDirectory(directoryPath) {
     // TODO will transmuters want to operate on directories?
     return fs.mkdirSync(this.createDestPath(directoryPath), { recursive: true });
   }
 
-  processFile(src) {
+  processFile(filePath) {
     let transmuter;
     let transmutedData = {};
 
     const transmuters = [...this.transmuters];
-    const { ext, name } = path.parse(src);
+    const { ext, name } = path.parse(filePath);
     const context = { src: this.src, dest: this.dest, layouts: this.layouts };
 
-    const fileBuffer = fs.readFileSync(src);
+    const fileBuffer = fs.readFileSync(filePath);
 
     const jpg = b => b.slice(0, 3).equals(Buffer.from([255, 216, 255]));
     const png = b => b.slice(0, 8).equals(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]));
-    const write = s => fs.writeFileSync(this.createDestPath(src), s);
-    const copy = () => fs.copyFileSync(src, this.createDestPath(src));
+    const copy = data => fs.copyFileSync(data, this.createDestPath(data));
+    const write = data => fs.writeFileSync(this.createDestPath(filePath, data), data.content);
     const transmutate = (transmutation) => {
       transmutedData = { ...transmutedData, ...transmutation };
       transmuter = transmuters.shift();
@@ -98,7 +92,7 @@ class Generator {
       transmuter(context, transmutedData, transmutate);
     }
 
-    return this.transmuters.length > 0 ? write(transmutedData.content) : copy();
+    return this.transmuters.length > 0 ? write(transmutedData) : copy(filePath);
   }
 
   traverse(directoryHandler, fileHandler, node) {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -21,18 +21,18 @@ class Logger {
   }
 
   message(text, { elapseTime, status }) {
-    let formattedMessage = `${new Date().toLocaleTimeString()}: ${text}`;
+    let message = `${new Date().toLocaleTimeString()}: ${text}`;
     if (elapseTime) {
       const timeLapse = this.stop - this.start;
-      const formattedTime = timeLapse >= 1000 ? `${timeLapse / 1000}s` : `${timeLapse}ms`;
+      const time = timeLapse >= 1000 ? `${timeLapse / 1000}s` : `${timeLapse}ms`;
       if (this.stop > 0) {
-        formattedMessage += ` - finished in ~${formattedTime}`;
+        message += ` - finished in ~${time}`;
       }
     }
     let type = 'log';
     if (status === 'warning') type = 'warn';
     if (status === 'danger') type = 'error';
-    console[type](`\x1b[3${colors[status]}m%s\x1b[0m`, formattedMessage);
+    console[type](`\x1b[3${colors[status]}m%s\x1b[0m`, type === 'error' ? `${message}\n\n${text.stack}\n` : message);
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@alchemy-js/alchemy",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alchemy-js/alchemy",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A dependency-light static site generator",
   "main": "index.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -46,12 +46,27 @@ Alchemy's chainable API executes sychronously.
 const Alchemy = require('@alchemy-js/alchemy');
 
 // optional transmuter example
-const markdownTransmuter = () => (context, file, done) => {
+const exampleTransmuter = (options) => (context, file, done) => {
+  // available read-only properties from the context object
   const { src, dest, layouts } = context;
-  const { content, data, ext } = file;
-  // transmute incoming file data here!
-  done();
+  // available transmutable properties from file object
+  const { content, data, ext, name } = file;
+  // an example of a conditionally transmuted file
+  if (ext === '.some-ext-we-want-to-work-with') {
+    // operate on the incoming data from the above objects!
+    const transmutedContent = 'return the eventual transmuted data';
+    const transmutedData = 'can even transmute front-matter, if you choose';
+    const transmutedExt = '.some-new-extension';
+    // pass an object to done with updated values for whatever has changed
+    return done({
+      content: transmutedContent,
+      data: transmutedData,
+    });
+  }
+  // otherwise, we're done
+  return done();
 };
+
 	
 Alchemy({
     src: './data',
@@ -64,7 +79,7 @@ Alchemy({
     '.md': '.html',
   })
   // optional transmute method accepts a function to operate upon file data
-  .transmute(markdownTransmuter())
+  .transmute(exampleTransmuter())
   .build()
   // optional watch method accepts an array of directories to listen to
   .watch([

--- a/test/generator.test.js
+++ b/test/generator.test.js
@@ -115,14 +115,6 @@ describe('Generator', () => {
     });
   });
 
-  describe('Generator.extensionMapper', () => {
-    it('should add a map to the instance to assist in mapping extensions of transmuted files', () => {
-      const expectedMap = { '.md': '.html' };
-      generator.extensionMapper(expectedMap);
-      expect(generator.extensionMap).toBe(expectedMap);
-    });
-  });
-
   describe('Generator.createDestPath', () => {
     it('should remove this.src from the path when outputting directories/files', () => {
       const srcPath = path.resolve('./test/fixture/data/index.md');

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -35,12 +35,13 @@ describe('Logger', () => {
 
   describe('Logger.message', () => {
     it('should format a message without an elapse time', () => {
+      const error = new Error();
       logger.message('test', { status: 'success' });
       logger.message('test', { status: 'warning' });
-      logger.message('test', { status: 'danger' });
+      logger.message(error, { status: 'danger' });
       expect(console.log).toHaveBeenNthCalledWith(1, successColor, `${now}: test`);
       expect(console.warn).toHaveBeenNthCalledWith(1, warningColor, `${now}: test`);
-      expect(console.error).toHaveBeenNthCalledWith(1, dangerColor, `${now}: test`);
+      expect(console.error).toHaveBeenNthCalledWith(1, dangerColor, `${now}: ${error}\n\n${error.stack}\n`);
     });
 
     it('should format a message with an elapse time in miliseconds', () => {


### PR DESCRIPTION
Closes #2 

- removes `extensionMapper` method
- improves `transmuter` callback function in terms of what data can be transmuted (can now modify the extension, name, and content data when these value are passed as an object)
- improves logger class when logging errors