### PR TITLE
feat: allow transmuters to ignore files from generation

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -75,10 +75,11 @@ class Generator {
 
     const image = jpg(fileBuffer) || png(fileBuffer);
 
-    transmutedData.ext = ext;
-    transmutedData.name = name;
-    transmutedData.data = null;
     transmutedData.content = fileBuffer;
+    transmutedData.data = null;
+    transmutedData.ext = ext;
+    transmutedData.ignore = false;
+    transmutedData.name = name;
 
     if (!image) {
       const { content, data } = matter(fileBuffer);
@@ -90,6 +91,10 @@ class Generator {
 
     while (transmuter) {
       transmuter(context, transmutedData, transmutate);
+    }
+
+    if (transmutedData.ignore) {
+      return false;
     }
 
     return this.transmuters.length > 0 ? write(transmutedData) : copy(filePath);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@alchemy-js/alchemy",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alchemy-js/alchemy",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A dependency-light static site generator",
   "main": "index.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -24,17 +24,17 @@ Alchemy's chainable API executes sychronously.
 - Cleans the destination directory
 - Useful when a file or directory has been removed in between builds
 
-##### Alchemy.extensionMap([object]) (optional)
-- Provides a map for when file extensions need to change due to transmutations
-
 ##### Alchemy.transmute([function]) (optional)
 - Transmute the contents of a file
 - Accepts a function that returns a function with `context`, `file`, and `done` parameters
   - `contenxt` provides an object with a reference to the instance's `this.src`, `this.dest`, and `this.layouts` paths
   - `file` is an object containing `content` and `data` key/values from `gray-matter` and the file `name` and `ext`
   - `done` is a callback function that is called once transmutations are completed
-    - this accepts an object that can contain whatever transmuted data that should be passed along
-    - it must contain the same keys found in `file`: content, data, name, and ext., along with corresponding updated data
+    - this accepts an object that can contain whatever data that was transmuted from the `file` object
+      - e.g., `{ content: 'new content here, ext: '.html' }`
+    - additionally, there is a property that can be passed to ignore a file entirely from generation
+      - e.g., `{ ignore: true }`
+    - if a file is not transmuted, call `done()` with no arguments to continue the process
 
 ##### Alchemy.build()
 - Builds the site in the `this.dest` directory
@@ -66,6 +66,9 @@ const exampleTransmuter = (options) => (context, file, done) => {
       name: transmutedName,
       ext: transmutedExt,
     });
+    /* optional "ignore" boolean can conditionally exclude files
+     * return done({ ignore: true });
+    */
   }
   // otherwise, we're done
   return done();

--- a/test/testData.js
+++ b/test/testData.js
@@ -12,6 +12,10 @@ module.exports = [{
   path: './test/fixture/public/index.md',
   content: Buffer.from('---\ntitle: Hello World\n---\n\n# Hello World!'),
 }, {
+  type: 'file',
+  path: './test/fixture/public/about.md',
+  content: Buffer.from('---\ntitle: About World\n---\n\n# About World!'),
+}, {
   type: 'dir',
   path: './test/fixture/public/images',
 }, {
@@ -47,6 +51,10 @@ module.exports = [{
   type: 'file',
   path: './test/fixture/data/index.md',
   content: Buffer.from('---\ntitle: Hello World\n---\n\n# Hello World!'),
+}, {
+  type: 'file',
+  path: './test/fixture/data/about.md',
+  content: Buffer.from('---\ntitle: About World\n---\n\n# About World!'),
 }, {
   type: 'dir',
   path: './test/fixture/data/images',


### PR DESCRIPTION
closes #4 

- adds functionality that allows the `done` callback to accept a property of "ignore" which is a boolean value that can exclude a file from being generated